### PR TITLE
Measure how long it takes to acquire a 9DOF reading

### DIFF
--- a/demos/mpu9250-getting-started/Cargo.lock
+++ b/demos/mpu9250-getting-started/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-adc-etc"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -105,7 +105,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-adc1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-aipstz1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -121,7 +121,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-aoi1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -129,7 +129,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-bee"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-can1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -145,7 +145,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-can3"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -153,7 +153,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-ccm"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -161,7 +161,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-ccm-analog"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-cmp1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -177,7 +177,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-core"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "bare-metal 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "cortex-m 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -187,7 +187,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-csi"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -195,7 +195,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-csu"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -203,7 +203,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-dcdc"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -211,7 +211,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-dcp"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-dma0"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-dmamux"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -235,7 +235,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-enc1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -243,7 +243,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-enet"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-ewm"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -259,12 +259,12 @@ dependencies = [
 [[package]]
 name = "imxrt1062-fcb-gen"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 
 [[package]]
 name = "imxrt1062-flexio1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -272,7 +272,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-flexram"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -280,7 +280,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-flexspi"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -288,7 +288,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-gpc"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -296,7 +296,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-gpio1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-gpt1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -312,11 +312,12 @@ dependencies = [
 [[package]]
 name = "imxrt1062-hal"
 version = "0.2.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cortex-m 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "embedded-hal 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "imxrt1062-pac 0.2.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
+ "imxrt1062-pac 0.2.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nb 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -325,7 +326,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-iomuxc"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -333,7 +334,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-iomuxc-gpr"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -341,7 +342,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-iomuxc-snvs"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -349,7 +350,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-iomuxc-snvs-gpr"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -357,7 +358,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-kpp"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -365,7 +366,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-lcdif"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -373,7 +374,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-lpi2c1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -381,7 +382,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-lpspi1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -389,7 +390,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-lpuart1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -397,7 +398,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-ocotp"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -405,77 +406,77 @@ dependencies = [
 [[package]]
 name = "imxrt1062-pac"
 version = "0.2.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "cortex-m 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "imxrt1062-adc-etc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-adc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-aipstz1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-aoi1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-bee 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-can1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-can3 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-ccm 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-ccm-analog 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-cmp1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-core 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-csi 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-csu 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-dcdc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-dcp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-dma0 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-dmamux 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-enc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-enet 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-ewm 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-flexio1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-flexram 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-flexspi 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-gpc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-gpio1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-gpt1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-iomuxc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-iomuxc-gpr 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-iomuxc-snvs 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-iomuxc-snvs-gpr 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-kpp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-lcdif 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-lpi2c1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-lpspi1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-lpuart1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-ocotp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-pgc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-pit 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-pmu 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-pwm1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-pxp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-romc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-rtwdog 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-sai1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-semc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-snvs 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-spdif 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-src 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-system-control 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-tempmon 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-tmr1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-trng 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-tsc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-usb-analog 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-usb1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-usbnc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-usbphy1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-usdhc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-wdog1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-xbara1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-xbarb2 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-xtalosc24m 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
+ "imxrt1062-adc-etc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-adc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-aipstz1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-aoi1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-bee 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-can1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-can3 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-ccm 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-ccm-analog 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-cmp1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-core 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-csi 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-csu 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-dcdc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-dcp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-dma0 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-dmamux 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-enc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-enet 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-ewm 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-flexio1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-flexram 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-flexspi 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-gpc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-gpio1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-gpt1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-iomuxc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-iomuxc-gpr 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-iomuxc-snvs 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-iomuxc-snvs-gpr 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-kpp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-lcdif 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-lpi2c1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-lpspi1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-lpuart1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-ocotp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-pgc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-pit 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-pmu 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-pwm1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-pxp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-romc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-rtwdog 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-sai1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-semc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-snvs 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-spdif 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-src 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-system-control 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-tempmon 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-tmr1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-trng 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-tsc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-usb-analog 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-usb1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-usbnc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-usbphy1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-usdhc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-wdog1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-xbara1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-xbarb2 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-xtalosc24m 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
 ]
 
 [[package]]
 name = "imxrt1062-pgc"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -483,7 +484,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-pit"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -491,7 +492,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-pmu"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -499,7 +500,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-pwm1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -507,7 +508,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-pxp"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -515,7 +516,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-romc"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -523,7 +524,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-rt"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "cortex-m 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -533,7 +534,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-rtwdog"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -541,7 +542,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-sai1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -549,7 +550,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-semc"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -557,7 +558,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-snvs"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -565,7 +566,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-spdif"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -573,7 +574,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-src"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -581,7 +582,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-system-control"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -589,7 +590,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-tempmon"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -597,7 +598,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-tmr1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -605,7 +606,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-trng"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -613,7 +614,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-tsc"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -621,7 +622,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-usb-analog"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -629,7 +630,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-usb1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -637,7 +638,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-usbnc1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -645,7 +646,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-usbphy1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -653,7 +654,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-usdhc1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -661,7 +662,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-wdog1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -669,7 +670,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-xbara1"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -677,7 +678,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-xbarb2"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -685,7 +686,7 @@ dependencies = [
 [[package]]
 name = "imxrt1062-xtalosc24m"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -773,22 +774,22 @@ dependencies = [
 [[package]]
 name = "teensy4-bsp"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "cortex-m 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "imxrt1062-hal 0.2.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "imxrt1062-rt 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
+ "imxrt1062-hal 0.2.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "imxrt1062-rt 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "teensy4-fcb 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
- "teensy4-usb-sys 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
+ "teensy4-fcb 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
+ "teensy4-usb-sys 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
 ]
 
 [[package]]
 name = "teensy4-fcb"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
- "imxrt1062-fcb-gen 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
+ "imxrt1062-fcb-gen 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
 ]
 
 [[package]]
@@ -799,13 +800,13 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mpu9250 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic-halt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "teensy4-bsp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)",
+ "teensy4-bsp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)",
 ]
 
 [[package]]
 name = "teensy4-usb-sys"
 version = "0.1.0"
-source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c#c865900d846fc088b15076c385c47c620e774900"
+source = "git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support#383e05e62292eb0b55589285804b7d0cfe2c3765"
 dependencies = [
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -851,72 +852,72 @@ dependencies = [
 "checksum embedded-hal 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ee4908a155094da7723c2d60d617b820061e3b4efcc3d9e293d206a5a76c170b"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
-"checksum imxrt1062-adc-etc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-adc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-aipstz1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-aoi1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-bee 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-can1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-can3 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-ccm 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-ccm-analog 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-cmp1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-core 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-csi 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-csu 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-dcdc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-dcp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-dma0 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-dmamux 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-enc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-enet 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-ewm 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-fcb-gen 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-flexio1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-flexram 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-flexspi 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-gpc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-gpio1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-gpt1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-hal 0.2.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-iomuxc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-iomuxc-gpr 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-iomuxc-snvs 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-iomuxc-snvs-gpr 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-kpp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-lcdif 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-lpi2c1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-lpspi1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-lpuart1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-ocotp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-pac 0.2.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-pgc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-pit 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-pmu 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-pwm1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-pxp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-romc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-rt 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-rtwdog 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-sai1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-semc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-snvs 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-spdif 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-src 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-system-control 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-tempmon 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-tmr1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-trng 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-tsc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-usb-analog 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-usb1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-usbnc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-usbphy1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-usdhc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-wdog1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-xbara1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-xbarb2 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum imxrt1062-xtalosc24m 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
+"checksum imxrt1062-adc-etc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-adc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-aipstz1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-aoi1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-bee 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-can1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-can3 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-ccm 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-ccm-analog 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-cmp1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-core 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-csi 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-csu 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-dcdc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-dcp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-dma0 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-dmamux 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-enc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-enet 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-ewm 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-fcb-gen 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-flexio1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-flexram 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-flexspi 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-gpc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-gpio1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-gpt1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-hal 0.2.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-iomuxc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-iomuxc-gpr 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-iomuxc-snvs 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-iomuxc-snvs-gpr 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-kpp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-lcdif 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-lpi2c1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-lpspi1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-lpuart1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-ocotp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-pac 0.2.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-pgc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-pit 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-pmu 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-pwm1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-pxp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-romc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-rt 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-rtwdog 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-sai1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-semc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-snvs 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-spdif 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-src 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-system-control 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-tempmon 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-tmr1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-trng 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-tsc 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-usb-analog 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-usb1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-usbnc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-usbphy1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-usdhc1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-wdog1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-xbara1 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-xbarb2 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum imxrt1062-xtalosc24m 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum mpu9250 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "587f98014056933f4f2326b0eb90da3d788e61525f82330867b0f15a79d57f02"
 "checksum nb 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b1411551beb3c11dedfb0a90a0fa256b47d28b9ec2cdff34c25a2fa59e45dbdc"
@@ -928,9 +929,9 @@ dependencies = [
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
-"checksum teensy4-bsp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum teensy4-fcb 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
-"checksum teensy4-usb-sys 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/i2c)" = "<none>"
+"checksum teensy4-bsp 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum teensy4-fcb 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
+"checksum teensy4-usb-sys 0.1.0 (git+https://github.com/mciantyre/teensy4-rs.git?branch=feature/async-support)" = "<none>"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vcell 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "876e32dcadfe563a4289e994f7cb391197f362b6315dc45e8ba4aa6f564a4b3c"

--- a/demos/mpu9250-getting-started/Cargo.toml
+++ b/demos/mpu9250-getting-started/Cargo.toml
@@ -18,4 +18,4 @@ features = ["i2c"]
 
 [dependencies.teensy4-bsp]
 git = "https://github.com/mciantyre/teensy4-rs.git"
-branch = "feature/i2c"
+branch = "feature/async-support"

--- a/demos/mpu9250-getting-started/src/control.rs
+++ b/demos/mpu9250-getting-started/src/control.rs
@@ -4,6 +4,9 @@
 //! on the MPU's 9DOF measurements. Provide an implementation of the
 //! `on_reading` function to work with MPU readings.
 
+use super::ClockSpeed;
+use core::time::Duration; // I2C clock selection
+
 /// Convenience for accessing data on x, y, and z axes.
 /// The `T` is a generic parameter. In practice, we'll
 /// work with 32-bit floats, `f32`.
@@ -27,23 +30,39 @@ pub struct Readings {
     pub temp: f32,
 }
 
+/// Select your I2C clock speed. Options are
+///
+/// - `KHz100` => 100 KHz clock
+/// - `KHz400` => 400 KHz clock
+/// - `MHz1` => 1 MHz clock (unsupported on the MPU)
+///
+/// The faster the clock, the faster we can query on the I2C bus
+pub const I2C_CLOCK_SPEED: ClockSpeed = ClockSpeed::KHz400;
+
 /// How long we should wait in between polling. This
 /// defines how frequently the `on_reading` function
 /// is called. Feel free to change me to something larger
 /// or smaller! It should be greater than 0.
-pub const SAMPLING_DELAY_MILLISECONDS: u32 = 250;
+pub const SAMPLING_DELAY_MILLISECONDS: u32 = 10;
 
 /// Called every SAMPLING_DELAY_MILLISECONDS in the sampling loop.
 /// The provided `readings` is the latest reading from the MPU.
-pub fn on_reading(readings: &Readings) {
+/// The `reading_duration` describes how long it took to acquire
+/// all readings via the I2C call. If the timer expired, the input is
+/// `None`.
+pub fn on_reading(readings: &Readings, reading_duration: Option<Duration>) {
     // Just printing the most-recent reading for now.
     // TODO make me do something cool!
     log::info!(
-        "Acc: x = {:.3}, y = {:.3}, z = {:.3}", // 2 decimal points
+        "Acc: x = {:.3}, y = {:.3}, z = {:.3}", // 3 decimal points
         readings.acc.x,
         readings.acc.y,
-        readings.acc.z
+        readings.acc.z,
     );
+
+    if let Some(duration) = reading_duration {
+        log::trace!("Took {:?} to query for all readings", duration);
+    }
 }
 
 // -------


### PR DESCRIPTION
We talked about how long it takes to read data over I2C. I updated the MPU example to measure the time it takes to read all accelerometer, gyroscope, and magnetometer measurements. It gave me a reason to implement timers in the hardware crate.

~2.5ms @ 100KHz. Here's the logic analyzer output. Top-right corner shows the measured time of the transaction. Software timer indicates the same timing.

![MPU_I2C_100KHz](https://user-images.githubusercontent.com/7933926/73596877-7a225200-44f4-11ea-8521-77886f8e438b.png)

We expect that we would be 4x faster at 400KHz. And yup, we see ~625us @ 400KHz. Logic analyzer output looks the same, but the scaling is different. Note the timing in the top-right corner. Software timer indicates the same thing.

![MPU_I2C_400KHz](https://user-images.githubusercontent.com/7933926/73596879-7db5d900-44f4-11ea-8cfc-d8e5bbcda82d.png)

The example now uses 400KHz by default. Change it in the `control.rs` module.