### PR TITLE
Reset to 0% throttle, implement real kill switch

### DIFF
--- a/demos/pwm-control/src/main.rs
+++ b/demos/pwm-control/src/main.rs
@@ -147,25 +147,25 @@ fn main() -> ! {
             // Parser has not found any command; it needs more inputs
             Ok(None) => bsp::delay(10),
             // User wants to reset all duty cycles
-            Ok(Some(Command::ResetDuty)) => {
-                output_a.set_duty(0);
-                output_b.set_duty(0);
-                output_c.set_duty(0);
-                output_d.set_duty(0);
-                log::info!("Reset all duty cycles");
+            Ok(Some(Command::ResetThrottle)) => {
+                output_a.set_duty(percent_to_duty(0.0));
+                output_b.set_duty(percent_to_duty(0.0));
+                output_c.set_duty(percent_to_duty(0.0));
+                output_d.set_duty(percent_to_duty(0.0));
+                log::info!("Reset all outputs to 0% throttle");
                 let blink_period =
                     pwm_to_blink_period(&[&output_a, &output_b, &output_c, &output_d]);
                 led_timer.start(blink_period);
             }
-            // User wants to read all the duty cycles
-            Ok(Some(Command::ReadDuty)) => {
+            // User wants to read all the throttle settings
+            Ok(Some(Command::ReadThrottle)) => {
                 print_duty('A', &output_a);
                 print_duty('B', &output_b);
                 print_duty('C', &output_c);
                 print_duty('D', &output_d);
             }
-            // User has set a duty cycle for an output PWM
-            Ok(Some(Command::SetDuty { output, percent })) => {
+            // User has set a throttle for an output
+            Ok(Some(Command::SetThrottle { output, percent })) => {
                 let pwm: &mut dyn PwmPin<Duty = u16> = match output {
                     Output::A => &mut output_a,
                     Output::B => &mut output_b,
@@ -218,6 +218,9 @@ fn pwm_to_blink_period(pwms: &[&dyn PwmPin<Duty = u16>]) -> Duration {
     }
 }
 
+/// Prints the duty cycle to the log channel
+///
+/// If the duty cycle is zero, print 'DISABLED'.
 fn print_duty(label: char, pwm: &dyn PwmPin<Duty = u16>) {
     let duty = pwm.get_duty();
     if duty == 0 {

--- a/demos/pwm-control/src/parser.rs
+++ b/demos/pwm-control/src/parser.rs
@@ -29,15 +29,15 @@ pub enum Output {
 /// A user command
 #[derive(Debug)]
 pub enum Command {
-    /// Set the duty cycle of the provided output to the
+    /// Set the throttle of the provided output to the
     /// specified percent.
     ///
     /// `percent` is bound from the closed range `[0, 100]`
-    SetDuty { output: Output, percent: f64 },
-    /// Read all duty cycle values
-    ReadDuty,
-    /// Reset all duty cycles
-    ResetDuty,
+    SetThrottle { output: Output, percent: f64 },
+    /// Read and report all throttle values
+    ReadThrottle,
+    /// Reset all throttle values
+    ResetThrottle,
 }
 
 /// Things that could go wrong when parsing commands
@@ -116,8 +116,8 @@ fn parse(buffer: &[u8]) -> Result<Option<Command>, ParserError> {
             b'B' => Output::B,
             b'C' => Output::C,
             b'D' => Output::D,
-            b'r' => return Ok(Some(Command::ReadDuty)),
-            b' ' => return Ok(Some(Command::ResetDuty)),
+            b'r' => return Ok(Some(Command::ReadThrottle)),
+            b' ' => return Ok(Some(Command::ResetThrottle)),
             _ => return Err(ParserError::InvalidPrefix(*output as char)),
         }
     } else {
@@ -147,7 +147,7 @@ fn parse(buffer: &[u8]) -> Result<Option<Command>, ParserError> {
 
     let percent: f64 = str::parse(pct_str.trim())?;
     if 0.0f64 <= percent && percent <= 100.0f64 {
-        Ok(Some(Command::SetDuty { output, percent }))
+        Ok(Some(Command::SetThrottle { output, percent }))
     } else {
         Err(ParserError::InvalidPercentage(percent))
     }

--- a/demos/pwm-control/src/parser.rs
+++ b/demos/pwm-control/src/parser.rs
@@ -38,6 +38,12 @@ pub enum Command {
     ReadThrottle,
     /// Reset all throttle values
     ResetThrottle,
+    /// Kill switch
+    ///
+    /// Pressing the kill switch sets all duty cycles to 0%, so there
+    /// is no output signal. The software will stop responding, and it
+    /// will require a reset to fix.
+    KillSwitch,
 }
 
 /// Things that could go wrong when parsing commands
@@ -118,6 +124,7 @@ fn parse(buffer: &[u8]) -> Result<Option<Command>, ParserError> {
             b'D' => Output::D,
             b'r' => return Ok(Some(Command::ReadThrottle)),
             b' ' => return Ok(Some(Command::ResetThrottle)),
+            b'\\' => return Ok(Some(Command::KillSwitch)),
             _ => return Err(ParserError::InvalidPrefix(*output as char)),
         }
     } else {


### PR DESCRIPTION
The PR changes the behavior of the SPACE bar in the `pwm-control` example. Pressing the SPACE bar resets the outputs to 0% throttle, not 0% duty cycle. We move the kill switch to the `\` key. Pressing the kill switch will set the duty cycles to 0%, then blocks the event loop. We'll be required to reset the system if we press the kill switch.

Closes #5