### PR TITLE
Generate pre-releases from master

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -22,12 +22,13 @@ jobs:
         run: ./task.py --verbose release
       - name: Create prerelease
         id: create_release
-        uses: actions/create-release@v1
+        # See https://github.com/actions/create-release/pull/32
+        uses: fleskesvor/create-release@feature/support-target-commitish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: demo-prerelease-${{ github.run_number }}
-          release_name: Demos at ${{ github.sha }}
+          tag_name: demo-prerelease
+          release_name: Demo Prerelease
           draft: false
           prerelease: true
       - name: Upload demos

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -26,8 +26,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: Demos at ${{ github.sha }}
           draft: true
           prerelease: true
       - name: Upload demos

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,42 @@
+on:
+  push:
+    branches: [master, feature/ci]
+
+name: Create demo prereleases
+
+jobs:
+  prerelease:
+    name: Build and upload demo prereleases
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install build dependencies
+        run: sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: thumbv7em-none-eabihf
+          override: true
+      - name: Run release task
+        run: ./task.py --verbose release
+      - name: Create prerelease
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: true
+      - name: Upload demos
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: target/thumbv7em-none-eabihf/release/demos.zip
+          asset_name: demos.zip
+          asset_content_type: application/zip

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [master, feature/ci]
+    branches: [master]
 
 name: Create demo prereleases
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -26,8 +26,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          tag_name: demo-prerelease-${{ github.run_number }}
           release_name: Demos at ${{ github.sha }}
-          draft: true
+          draft: false
           prerelease: true
       - name: Upload demos
         id: upload-release-asset 


### PR DESCRIPTION
Now that we have continuous builds and better task automation (#10), we can automatically build our apps and demos for the Teensy 4.

Every time we push commits to `master`, a CI job will automatically create a [pre-release](https://github.com/ebelski/rust-copter/releases). From that page, you can expand the assets, and download all the demos. The demos are ready to flash on a Teensy. In the future, we can add more apps and demos.

The top pre-release should always be the latest; it should also be accessible using the `demo-prerelease` git tag. This is just a convenience so that we don't have to manually build the code on `master`.

(Note that the two pre-releases, as of this writing, were generated during my testing. The system will kick-in once we merge this PR.)