### PR TITLE
Remove ARM toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
           toolchain: stable
           target: thumbv7em-none-eabihf
           override: true
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-binutils
+          version: latest
+          use-tool-cache: true
       - name: Run release task
         run: ./task.py --verbose release
       - name: Create release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
           toolchain: stable
           target: thumbv7em-none-eabihf
           override: true
+          components: llvm-tools-preview
       - uses: actions-rs/install@v0.1
         with:
           crate: cargo-binutils

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,6 @@ jobs:
     name: Build and upload demo release
     runs-on: ubuntu-latest
     steps:
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi
       - name: Checkout code
         uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/task.yml
+++ b/.github/workflows/task.yml
@@ -13,8 +13,6 @@ jobs:
   demos:
     runs-on: ubuntu-latest
     steps:
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/task.yml
+++ b/.github/workflows/task.yml
@@ -19,6 +19,7 @@ jobs:
             toolchain: stable
             target: thumbv7em-none-eabihf
             override: true
+            components: llvm-tools-preview
       - uses: actions-rs/install@v0.1
         with:
           crate: cargo-binutils

--- a/.github/workflows/task.yml
+++ b/.github/workflows/task.yml
@@ -19,6 +19,11 @@ jobs:
             toolchain: stable
             target: thumbv7em-none-eabihf
             override: true
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-binutils
+          version: latest
+          use-tool-cache: true
       - name: Run task for pwm-control demo
         run: ./task.py --verbose demo pwm-control --skip-flash
       - name: Run task for pwm-control demo ('demo-' prefix)

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -14,8 +14,6 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,6 +21,11 @@ jobs:
             components: clippy
             target: thumbv7em-none-eabihf
             override: true
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-binutils
+          version: latest
+          use-tool-cache: true
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,11 +21,6 @@ jobs:
             components: clippy
             target: thumbv7em-none-eabihf
             override: true
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-binutils
-          version: latest
-          use-tool-cache: true
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/demos/mpu9250-i2c/src/main.rs
+++ b/demos/mpu9250-i2c/src/main.rs
@@ -14,6 +14,9 @@
 // We're going to write our own main() function, rather than
 // using the normal, 'special' main() function.
 #![no_main]
+// This seems to be a bad lint. The patter is valid
+// for a non_exhaustive struct.
+#![allow(clippy::field_reassign_with_default)]
 
 // -------
 // Imports

--- a/demos/mpu9250-spi/src/main.rs
+++ b/demos/mpu9250-spi/src/main.rs
@@ -7,6 +7,9 @@
 
 #![no_std]
 #![no_main]
+// This seems to be a bad lint. The patter is valid
+// for a non_exhaustive struct.
+#![allow(clippy::field_reassign_with_default)]
 
 extern crate panic_halt;
 

--- a/demos/pwm-control/src/main.rs
+++ b/demos/pwm-control/src/main.rs
@@ -73,6 +73,9 @@
 
 #![no_std]
 #![no_main]
+// This seems to be a bad lint. The patter is valid
+// for a non_exhaustive struct.
+#![allow(clippy::field_reassign_with_default)]
 
 mod datapath;
 mod parser;

--- a/demos/pwm-control/src/parser.rs
+++ b/demos/pwm-control/src/parser.rs
@@ -146,7 +146,7 @@ fn parse(buffer: &[u8]) -> Result<Option<Command>, ParserError> {
     }
 
     let percent: f32 = str::parse(pct_str.trim())?;
-    if 0.0f32 <= percent && percent <= 100.0f32 {
+    if (0.0f32..=100.0f32).contains(&percent) {
         Ok(Some(Command::SetThrottle { output, percent }))
     } else {
         Err(ParserError::InvalidPercentage(percent))

--- a/task.py
+++ b/task.py
@@ -36,7 +36,7 @@ from zipfile import ZipFile
 
 RUSTFLAGS = "-C link-arg=-Tt4link.x"
 TARGET = "thumbv7em-none-eabihf"
-OBJCOPY = "arm-none-eabi-objcopy"
+OBJCOPY = "rust-objcopy"
 TEENSY_LOADER = "teensy_loader_cli"
 DEMOS = [
     "demo-mpu9250-i2c",


### PR DESCRIPTION
The PR removes our dependency on ARM binutils, and the ARM toolchain. Instead, we favor `cargo binutils`, and the dependencies recommended by the [teensy4-rs project](https://github.com/mciantyre/teensy4-rs#dependencies).