### PR TITLE
Add cross-platform, host-side tool testing

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -1,0 +1,50 @@
+# Checks for host-side tools
+
+name: Tools
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  # Ensure that the pymotion-sensor library works builds
+  # on macOS, Ubuntu, and Windows
+  pymotion-sensor:
+    strategy:
+      matrix:
+        host: [ macos-latest, ubuntu-latest, windows-latest ]
+        python-version: [ 3.7, 3.8, 3.9 ]
+    runs-on: ${{ matrix.host }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install maturin
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install maturin
+    - name: Build pymotion-sensor
+      run: maturin develop --manifest-path tools/pymotion-sensor/Cargo.toml
+    - name: Check pymotion-sensor installation
+      run: python -c "import motion_sensor"
+
+  imu-parse:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    # See https://github.com/psf/black/issues/1654 for why we're
+    # locking black version.
+    - name: Install formatter
+      run: |
+        python -m pip install --upgrade pip
+        pip install black==19.10b0
+    - name: Check formatting of tools/imu-parse.py
+      run: black --check tools/imu-parse.py

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -29,7 +29,8 @@ jobs:
         python -m pip install maturin
     - name: Build and install pymotion-sensor
       run: |
-        maturin build --manifest-path tools/pymotion-sensor/Cargo.toml --out wheels
+        maturin build --manifest-path tools/pymotion-sensor/Cargo.toml --out wheels --manylinux off
+        ls -al wheels
         python -m pip install wheels/*.whl
     - name: Check pymotion-sensor installation
       run: python -c "import motion_sensor"

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -29,8 +29,7 @@ jobs:
         python -m pip install maturin
     - name: Build and install pymotion-sensor
       run: |
-        maturin build --manifest-path tools/pymotion-sensor/Cargo.toml --out wheels --manylinux off
-        ls -al wheels
+        maturin build --manifest-path tools/pymotion-sensor/Cargo.toml --out wheels --manylinux off --interpreter python${{ matrix.python-version }}
         python -m pip install wheels/*.whl
     - name: Check pymotion-sensor installation
       run: python -c "import motion_sensor"

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -27,8 +27,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install maturin
-    - name: Build pymotion-sensor
-      run: maturin develop --manifest-path tools/pymotion-sensor/Cargo.toml
+    - name: Build and install pymotion-sensor
+      run: |
+        maturin build --manifest-path tools/pymotion-sensor/Cargo.toml --out wheels
+        python -m pip install wheels/*.whl
     - name: Check pymotion-sensor installation
       run: python -c "import motion_sensor"
 

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [ master ]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # Ensure that the pymotion-sensor library works builds
   # on macOS, Ubuntu, and Windows

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -27,10 +27,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install maturin
-    - name: Build and install pymotion-sensor
-      run: |
-        maturin build --manifest-path tools/pymotion-sensor/Cargo.toml --out wheels --manylinux off --interpreter python${{ matrix.python-version }}
-        python -m pip install wheels/*.whl
+    - name: List Python interpreters
+      run: maturin list-python
+    - name: Build pymotion-sensor
+      run: maturin build --manifest-path tools/pymotion-sensor/Cargo.toml --out wheels --manylinux off --interpreter python
+    - name: Install pymotion-sensor
+      run: python -m pip install wheels/*.whl
     - name: Check pymotion-sensor installation
       run: python -c "import motion_sensor"
 

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -25,7 +25,12 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --verbose --target thumbv7em-none-eabihf -- -D warnings
-          name: Run clippy
+          name: Run clippy for workspace
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --verbose --manifest-path tools/pymotion-sensor/Cargo.toml -- -D warnings
+          name: Run clippy for tools/pymotion-sensor
 
   # Ensure code is formatted
   format:
@@ -33,11 +38,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: rustup component add rustfmt
-    - name: Check code formatting
+    - name: Check code formatting for workspace
       uses: actions-rs/cargo@v1
       with:
           command: fmt
           args: --verbose --all -- --check
+    - name: Check code formatting for tools/pymotion-sensor
+      uses: actions-rs/cargo@v1
+      with:
+          command: fmt
+          args: --verbose --manifest-path tools/pymotion-sensor/Cargo.toml -- --check
 
   # Build all Rust code on macOS, Ubuntu, and Windows
   xplat:

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -38,3 +38,20 @@ jobs:
       with:
           command: fmt
           args: --verbose --all -- --check
+
+  # Build all Rust code on macOS, Ubuntu, and Windows
+  xplat:
+    strategy:
+      matrix:
+        host: [ macos-latest, ubuntu-latest, windows-latest ]
+    runs-on: ${{ matrix.host }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+            profile: minimal
+            toolchain: stable
+            target: thumbv7em-none-eabihf
+            override: true
+      - name: Build examples
+        run: cargo build --workspace --target thumbv7em-none-eabihf

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 .vscode/
 pyenv/
 tools/pymotion-sensor/Cargo.lock
+wheels/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,8 @@ members = [
 exclude = [
     "tools/pymotion-sensor",
 ]
+
+# Don't optimize build dependencies, like proc macros.
+# Helps with build times.
+[profile.release.build-override]
+opt-level = 0

--- a/tools/pymotion-sensor/Cargo.toml
+++ b/tools/pymotion-sensor/Cargo.toml
@@ -9,7 +9,7 @@ name = "motion_sensor"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.11.1"
+version = "0.13.1"
 features = ["extension-module"]
 
 [dependencies.motion-sensor]

--- a/tools/pymotion-sensor/Cargo.toml
+++ b/tools/pymotion-sensor/Cargo.toml
@@ -20,3 +20,8 @@ features = ["use-serde"]
 version = "0.5"
 default-features = false
 features = ["use-std"]
+
+# Don't optimize build dependencies, like proc macros.
+# Helps with build times.
+[profile.release.build-override]
+opt-level = 0

--- a/tools/pymotion-sensor/src/lib.rs
+++ b/tools/pymotion-sensor/src/lib.rs
@@ -1,4 +1,4 @@
-use pyo3::exceptions::ValueError;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyByteArray;
 use pyo3::wrap_pyfunction;
@@ -104,7 +104,7 @@ pub fn convert_readings(py: Python, buffer: &PyByteArray) -> PyResult<Vec<PyObje
     let buffer = unsafe { buffer.as_bytes_mut() };
     let readings: Vec<Reading> = match postcard::from_bytes_cobs(buffer) {
         Err(err) => {
-            return Err(PyErr::new::<ValueError, _>(format!(
+            return Err(PyErr::new::<PyValueError, _>(format!(
                 "error converting readings: {:?}",
                 err,
             )));


### PR DESCRIPTION
- Ensure that we can perform the minimal build of embedded code across Windows, macOS, and Ubuntu
- Add automated tests for the `pymotion-sensor` library
  - Builds on Windows, macOS, Ubuntu
  - For each platform, test with Python 3.7, 3.8, and 3.9
  - Ensure that the library can be loaded in a Python environment
- Check formatting, and lint host-side Rust and Python code