### PR TITLE
Docs: separate checks for Python interp, version

### DIFF
--- a/.github/workflows/first-time-setup.yml
+++ b/.github/workflows/first-time-setup.yml
@@ -27,7 +27,7 @@ jobs:
   first-time-setup:
     strategy:
       matrix:
-        host: [ macos-latest, ubuntu-latest ]
+        host: [ macos-latest, ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.host }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/first-time-setup.yml
+++ b/.github/workflows/first-time-setup.yml
@@ -5,6 +5,10 @@ name: First Time Setup
 on:
   schedule:
   - cron: "15 14 */13 * *"  # at 2:15PM on each 13th day of the month
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 defaults:
   run:

--- a/docs/first-time-setup.sh
+++ b/docs/first-time-setup.sh
@@ -55,12 +55,16 @@ cargo build
 popd &> /dev/null
 echo "[✓] OK build of all embedded and host-side Rust code"
 
-# Check for Python installation with minimum version
-# for versions. TODO check version.
-if ! python -c "import sys; assert sys.version_info[0] == 3 and sys.version_info[1] > 6" &> /dev/null
+# Check for a Python interpreter, and make sure it's at least Python 3.7
+if ! command -v python &> /dev/null
 then
-    echo "[!] Cannot find Python interpreter at 'python', or installation is not the 3.7 min version"
-    echo "[!] Make sure you have at least a Python 3.7 installation available"
+    echo "[!] Cannot find Python interpreter at 'python'"
+    echo "    Make sure you have a Python interpreter available"
+elif ! python -c "import sys; assert sys.version_info[0] == 3 and sys.version_info[1] > 6" &> /dev/null
+then
+    echo "[!] Python interpreter 'python' is not the min version 3.7"
+    echo "    Make sure your 'python' interpreter is at least version 3.7"
+    echo "    Hint: use a virtual environment generated from your Python 3 installation"
 else
     echo "[✓] Found Python installation with interpreter 'python' and min version 3.7"
 fi


### PR DESCRIPTION
Separate the check for the Python interpreter from the check for the Python version. This could help with troubleshooting, since we won't have to manually isolate the user's issue.

If `python` points to an installation that we don't support, hint that the user should [use a virtual environment](https://docs.python.org/3/tutorial/venv.html).

Run the first-time setup checks on pull requests.