### PR TITLE
Fix clippy, tools build in CI

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install maturin
       run: |
         python -m pip install --upgrade pip
-        python -m pip install maturin
+        python -m pip install 'maturin>=0.9,<0.10'
     - name: List Python interpreters
       run: maturin list-python
     - name: Build pymotion-sensor

--- a/demos/mpu9250-i2c/src/main.rs
+++ b/demos/mpu9250-i2c/src/main.rs
@@ -86,7 +86,7 @@ fn main() -> ! {
             );
             loop {
                 // Nothing more to do
-                core::sync::atomic::spin_loop_hint();
+                core::hint::spin_loop();
             }
         }
     }
@@ -113,7 +113,7 @@ fn main() -> ! {
             log::error!("Unable to create MPU9250: {:?}", err);
             loop {
                 // This is it, we stop the example here.
-                core::sync::atomic::spin_loop_hint()
+                core::hint::spin_loop()
             }
         }
         // Connected OK to the MPU!

--- a/demos/mpu9250-spi/src/main.rs
+++ b/demos/mpu9250-spi/src/main.rs
@@ -64,7 +64,7 @@ fn main() -> ! {
                 err
             );
             loop {
-                core::sync::atomic::spin_loop_hint()
+                core::hint::spin_loop()
             }
         }
     };
@@ -84,7 +84,7 @@ fn main() -> ! {
         Err(err) => {
             log::error!("Error when constructing MP9250: {:?}", err);
             loop {
-                core::sync::atomic::spin_loop_hint();
+                core::hint::spin_loop();
             }
         }
     };

--- a/demos/pwm-control/src/main.rs
+++ b/demos/pwm-control/src/main.rs
@@ -90,8 +90,8 @@ use embedded_hal::{digital::v2::OutputPin, timer::CountDown};
 use parser::{Command, Parser};
 use teensy4_bsp as bsp;
 
-use esc::{QuadMotor, ESC};
-use esc_imxrt1062::{Protocol, ESC as imxrtESC};
+use esc::{Esc, QuadMotor};
+use esc_imxrt1062::{Esc as imxrtEsc, Protocol};
 
 /// CHANGE ME to vary the ESC protocol
 const ESC_PROTOCOL: Protocol = Protocol::OneShot125;
@@ -158,7 +158,7 @@ fn main() -> ! {
         )
         .unwrap();
 
-    let mut esc = imxrtESC::new(ESC_PROTOCOL, pwm1.handle, sm3, pwm2.handle, sm2);
+    let mut esc = imxrtEsc::new(ESC_PROTOCOL, pwm1.handle, sm3, pwm2.handle, sm2);
 
     // Set up the USB stack, and use the USB reader for parsing commands
     let usb_reader = bsp::usb::init(&systick, Default::default()).unwrap();
@@ -192,7 +192,7 @@ fn main() -> ! {
         Err(err) => {
             log::error!("Unable to establish datapath: {:?}", err);
             loop {
-                core::sync::atomic::spin_loop_hint();
+                core::hint::spin_loop();
             }
         }
     };
@@ -217,7 +217,7 @@ fn main() -> ! {
             );
             loop {
                 // Nothing more to do
-                core::sync::atomic::spin_loop_hint();
+                core::hint::spin_loop();
             }
         }
     }
@@ -309,7 +309,7 @@ fn percent_to_duty(pct: f64) -> u16 {
 /// Compute the rate at which we should blink the LED based on the
 /// PWM duty cycles. Defines a duration based on the highest PWM
 /// duty cycle.
-fn pwm_to_blink_period(esc: &dyn ESC<Motor = QuadMotor>) -> Duration {
+fn pwm_to_blink_period(esc: &dyn Esc<Motor = QuadMotor>) -> Duration {
     const SLOWEST_BLINK_NS: i64 = 2_000_000_000;
     const FASTEST_BLINK_NS: i64 = SLOWEST_BLINK_NS / 100;
     const MOTORS: [QuadMotor; 4] = [QuadMotor::A, QuadMotor::B, QuadMotor::C, QuadMotor::D];

--- a/demos/pwm-control/src/sensor.rs
+++ b/demos/pwm-control/src/sensor.rs
@@ -5,7 +5,7 @@ use embedded_hal::{
     blocking::i2c::{Write, WriteRead},
     timer::{CountDown, Periodic},
 };
-use invensense_mpu::MPU;
+use invensense_mpu::Mpu;
 use motion_sensor::*;
 
 const POLLING_INTERVAL: Duration = Duration::from_micros(10_000);
@@ -13,7 +13,7 @@ const POLLING_INTERVAL: Duration = Duration::from_micros(10_000);
 pub struct Sensor<P, I> {
     timer: P,
     write: crate::datapath::Datapath,
-    mpu: Option<MPU<invensense_mpu::i2c::Bypass<I>>>,
+    mpu: Option<Mpu<invensense_mpu::i2c::Bypass<I>>>,
 }
 
 impl<P, I, E> Sensor<P, I>

--- a/libs/esc-imxrt1062/src/lib.rs
+++ b/libs/esc-imxrt1062/src/lib.rs
@@ -181,9 +181,9 @@ where
 }
 
 /// i.MX RT-specific ESC implementation
-pub struct ESC<A, B, C, D>(RefCell<Module<A, B, C, D>>);
+pub struct Esc<A, B, C, D>(RefCell<Module<A, B, C, D>>);
 
-impl<A, B, C, D> ESC<A, B, C, D>
+impl<A, B, C, D> Esc<A, B, C, D>
 where
     A: Pin<Module = XMod, Output = pwm::A, Submodule = XSub>,
     B: Pin<Module = XMod, Output = pwm::B, Submodule = <A as Pin>::Submodule>,
@@ -222,7 +222,7 @@ fn duty_to_percent(duty: u16) -> f32 {
     (duty.saturating_sub(MINIMUM_DUTY_CYCLE) as f32) / (MINIMUM_DUTY_CYCLE as f32)
 }
 
-impl<A, B, C, D> esc::ESC for ESC<A, B, C, D>
+impl<A, B, C, D> esc::Esc for Esc<A, B, C, D>
 where
     A: Pin<Module = XMod, Output = pwm::A, Submodule = XSub>,
     B: Pin<Module = XMod, Output = pwm::B, Submodule = <A as Pin>::Submodule>,

--- a/libs/esc/src/lib.rs
+++ b/libs/esc/src/lib.rs
@@ -18,7 +18,7 @@ pub enum QuadMotor {
 }
 
 /// An electronic speed control
-pub trait ESC {
+pub trait Esc {
     /// Identifiers for motors
     ///
     /// `QuadMotor` is an example of a possible `Motor` type.

--- a/libs/invensense-mpu/src/lib.rs
+++ b/libs/invensense-mpu/src/lib.rs
@@ -59,26 +59,26 @@ impl<P> From<P> for Error<P> {
 /// The `MPU` struct can be used to query readings from a physical
 /// MPU. See the [`spi`](spi/index.html) and [`i2c`](i2c/index.html)
 /// module documentation for details on how to acquire an `MPU`.
-pub struct MPU<T> {
+pub struct Mpu<T> {
     transport: T,
     handle: Handle,
 }
 
 type Sensitivity = Triplet<f32>;
 
-impl<T> MPU<T>
+impl<T> Mpu<T>
 where
     T: Transport,
 {
     fn new(transport: T, config: &Config, sensitivity: &Sensitivity) -> Self {
-        MPU {
+        Mpu {
             transport,
             handle: Handle::new(&config, sensitivity),
         }
     }
 }
 
-impl<T> MPU<T> {
+impl<T> Mpu<T> {
     fn scale_gyro(&self, raw: Triplet<i16>) -> Triplet<f32> {
         raw.map(|raw| self.handle.gyro_resolution * f32::from(raw))
     }
@@ -96,7 +96,7 @@ impl<T> MPU<T> {
     }
 }
 
-impl<T> MPU<T>
+impl<T> Mpu<T>
 where
     T: Transport,
     T::Error: Debug,
@@ -141,7 +141,7 @@ pub trait Transport: private::Sealed {
 mod private {
     pub trait Sealed {}
     impl<I> Sealed for crate::i2c::Bypass<I> {}
-    impl<S> Sealed for crate::spi::SPI<S> {}
+    impl<S> Sealed for crate::spi::Spi<S> {}
 }
 
 /// Holds controller-side state of the MPU9250

--- a/libs/motion-sensor/src/lib.rs
+++ b/libs/motion-sensor/src/lib.rs
@@ -51,7 +51,7 @@ pub trait Magnetometer<V = DefaultScalar> {
 /// The default implementation simply queries the accelerometer, then queries the
 /// gyroscope. Implementations that can perform a more efficient query should do
 /// so.
-pub trait DOF6<A = DefaultScalar, G = DefaultScalar>:
+pub trait Dof6<A = DefaultScalar, G = DefaultScalar>:
     Accelerometer<A> + Gyroscope<G, Error = <Self as Accelerometer<A>>::Error>
 {
     fn dof6(&mut self) -> Result<(Gs<A>, DegPerSec<G>), <Self as Accelerometer<A>>::Error> {
@@ -62,19 +62,19 @@ pub trait DOF6<A = DefaultScalar, G = DefaultScalar>:
 /// A tuple of accelerometer, gyroscope, and magnetometer readings
 ///
 /// See [`MARG`](trait.MARG.html) for more information.
-pub type MARGReadings<A = DefaultScalar, G = DefaultScalar, M = DefaultScalar> =
+pub type MargReadings<A = DefaultScalar, G = DefaultScalar, M = DefaultScalar> =
     (Gs<A>, DegPerSec<G>, MicroT<M>);
 
 /// All three of a accelerometer, magnetometer, and gyroscope
 ///
 /// The default implementation queries for all three readings separately.
 /// Consider providing a querying optimization if you're able to do so.
-pub trait MARG<A = DefaultScalar, G = DefaultScalar, M = DefaultScalar>:
+pub trait Marg<A = DefaultScalar, G = DefaultScalar, M = DefaultScalar>:
     Accelerometer<A>
     + Gyroscope<G, Error = <Self as Accelerometer<A>>::Error>
     + Magnetometer<M, Error = <Self as Accelerometer<A>>::Error>
 {
-    fn marg(&mut self) -> Result<MARGReadings<A, G, M>, <Self as Accelerometer<A>>::Error> {
+    fn marg(&mut self) -> Result<MargReadings<A, G, M>, <Self as Accelerometer<A>>::Error> {
         Ok((
             self.accelerometer()?,
             self.gyroscope()?,

--- a/libs/mpu9250-regs/src/lib.rs
+++ b/libs/mpu9250-regs/src/lib.rs
@@ -5,6 +5,7 @@
 //! each module for more information.
 
 #![no_std]
+#![allow(clippy::upper_case_acronyms)]
 
 pub mod ak8963;
 pub mod mpu9250;

--- a/tools/README.md
+++ b/tools/README.md
@@ -17,7 +17,7 @@ The library is written in Rust. We recommend using
 [maturin](https://github.com/PyO3/maturin) to build and install the library.
 
 ```bash
-$ pip install maturin
+$ pip install 'maturin>=0.9,<0.10'
 $ maturin build --release --manifest-path tools/pymotion-sensor/Cargo.toml
 ```
 


### PR DESCRIPTION
The PR addresses new warnings emitted from [clippy](https://github.com/rust-lang/rust-clippy), the linter:

- Favor naming conventions and don't use upper-case acronyms. Most changes in this PR resemble `ESC => Esc`
- Replace deprecated methods

The latter requires that we update to Rust 1.49. To guarantee that you're up to date, run

```
rustup update
```

The PR also pins our version of the `maturin` tool. The latest version doesn't seem to be selecting the compilation target we want, so we'll wait for new changes in their project to settle before upgrading.