### PR TITLE
Set PWM pin muxing in pwm-control example

### DIFF
--- a/firmware/demos-teensy4/pwm-control/main.rs
+++ b/firmware/demos-teensy4/pwm-control/main.rs
@@ -120,7 +120,7 @@ fn main() -> ! {
     let mut peripherals = bsp::Peripherals::take().unwrap();
     let core_peripherals = cortex_m::Peripherals::take().unwrap();
     let mut systick = bsp::SysTick::new(core_peripherals.SYST);
-    let pins = bsp::t40::into_pins(peripherals.iomuxc);
+    let mut pins = bsp::t40::into_pins(peripherals.iomuxc);
 
     let mut led = bsp::configure_led(pins.p13);
 
@@ -146,6 +146,8 @@ fn main() -> ! {
     let switching_period = Duration::from_micros(5_000);
 
     // Configure pins 6 and 9 as PWM outputs
+    esc_imxrt1062::prepare_pin(&mut pins.p6);
+    esc_imxrt1062::prepare_pin(&mut pins.p9);
     let sm2 = pwm2
         .sm2
         .outputs(
@@ -161,6 +163,8 @@ fn main() -> ! {
         .unwrap();
 
     // Configure pins 7 and 8 as PWM outputs
+    esc_imxrt1062::prepare_pin(&mut pins.p8);
+    esc_imxrt1062::prepare_pin(&mut pins.p7);
     let sm3 = pwm1
         .sm3
         .outputs(

--- a/firmware/esc-imxrt1062/src/lib.rs
+++ b/firmware/esc-imxrt1062/src/lib.rs
@@ -83,6 +83,11 @@ impl Protocol {
     }
 }
 
+/// Call this on your i.MX RT pads before constructing your ESC
+///
+/// TODO remove with 0.4.4 imxrt-hal release.
+pub use pwm::prepare as prepare_pin;
+
 /// i.MX RT-specific ESC implementation
 struct Module<A, B, C, D> {
     handle_ab: Handle<XMod>,


### PR DESCRIPTION
This patch fixes the `pwm-control` example. Before this commit, the PWM outputs were constantly low. Now, the PWM outputs initialize to the 50% duty cycle. This duty cycle correlates to 0% throttle for OneShot125.

Set motor B to 50% throttle: 
```
python3 host/esc-throttle.py /dev/tty.usbmodem62987801 B 50
```

Observe a faster duty cycle:

<img width="1034" alt="Screen Shot 2021-04-22 at 9 07 22 PM" src="https://user-images.githubusercontent.com/7933926/115803451-e239ae00-a3ae-11eb-8c31-7cd853c3adde.png">

Root cause is down in the PWM driver. See [here](https://github.com/imxrt-rs/imxrt-hal/pull/108/commits/29cc21a10c62df3960cf763a87e6c3d990298137) for details and a fix. We can revert this commit when the bug is fixed in a future HAL release.

See #42 for the initial report.