### PR TITLE
Proper panic

### DIFF
--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -406,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "teensy4-panic"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47dd0d4933669a6d729b07a67f9d0cd97fd431c0729a0d18a8d10cf2a98de60"
+checksum = "e307eec1203a9b340f41d77d72357fa6e327b1ab9b12d593725a5ce17236b2da"
 
 [[package]]
 name = "teensy4-pins"

--- a/firmware/demos-teensy4/Cargo.toml
+++ b/firmware/demos-teensy4/Cargo.toml
@@ -14,7 +14,7 @@ imxrt-uart-log = "0.2"
 invensense-mpu = { path = "../../common/invensense-mpu" }
 motion-sensor = { path = "../../common/motion-sensor", features = ["use-serde"] }
 postcard = { version = "0.5", default-features = false }
-teensy4-panic = "0.1.0"
+teensy4-panic = { version = "0.2", default-features = false }
 void = { version = "1.0.2", default-features = false }
 
 [dependencies.esc]
@@ -30,6 +30,10 @@ features = ["release_max_level_debug"]
 [dependencies.teensy4-bsp]
 version = "0.1"
 features = ["rt"]
+
+[lib]
+name = "shared"
+path = "shared/lib.rs"
 
 [[bin]]
 name = "mpu9250-i2c"

--- a/firmware/demos-teensy4/mpu9250-i2c.rs
+++ b/firmware/demos-teensy4/mpu9250-i2c.rs
@@ -21,9 +21,9 @@
 // -------
 // Imports
 // -------
-extern crate teensy4_panic;
 use bsp::hal::i2c::ClockSpeed;
 use motion_sensor::*;
+use shared as _;
 use teensy4_bsp as bsp; // Aliasing teensy4_bsp as bsp for convenience
 
 const I2C_CLOCK_SPEED: ClockSpeed = ClockSpeed::KHz400;

--- a/firmware/demos-teensy4/mpu9250-i2c.rs
+++ b/firmware/demos-teensy4/mpu9250-i2c.rs
@@ -79,15 +79,10 @@ fn main() -> ! {
     match i2c3.set_clock_speed(I2C_CLOCK_SPEED) {
         Ok(_) => (),
         Err(err) => {
-            log::error!(
+            panic!(
                 "Unable to set I2C clock speed to {:?}: {:?}",
-                I2C_CLOCK_SPEED,
-                err
+                I2C_CLOCK_SPEED, err
             );
-            loop {
-                // Nothing more to do
-                core::hint::spin_loop();
-            }
         }
     }
 
@@ -110,11 +105,7 @@ fn main() -> ! {
     let mut sensor = match invensense_mpu::i2c::new(i2c3, &mut systick, &config) {
         // Damn, something went wrong when connecting to the MPU!
         Err(err) => {
-            log::error!("Unable to create MPU9250: {:?}", err);
-            loop {
-                // This is it, we stop the example here.
-                core::hint::spin_loop()
-            }
+            panic!("Unable to create MPU9250: {:?}", err);
         }
         // Connected OK to the MPU!
         Ok(mpu) => mpu,

--- a/firmware/demos-teensy4/mpu9250-spi.rs
+++ b/firmware/demos-teensy4/mpu9250-spi.rs
@@ -58,14 +58,10 @@ fn main() -> ! {
             log::info!("Set clock speed to {}Hz", SPI_BAUD_RATE_HZ);
         }
         Err(err) => {
-            log::error!(
+            panic!(
                 "Unable to set clock speed to {}Hz: {:?}",
-                SPI_BAUD_RATE_HZ,
-                err
+                SPI_BAUD_RATE_HZ, err
             );
-            loop {
-                core::hint::spin_loop()
-            }
         }
     };
 
@@ -82,10 +78,7 @@ fn main() -> ! {
     let mut sensor = match invensense_mpu::spi::new(spi4, &mut systick, &config) {
         Ok(sensor) => sensor,
         Err(err) => {
-            log::error!("Error when constructing MP9250: {:?}", err);
-            loop {
-                core::hint::spin_loop();
-            }
+            panic!("Error when constructing MP9250: {:?}", err);
         }
     };
 

--- a/firmware/demos-teensy4/mpu9250-spi.rs
+++ b/firmware/demos-teensy4/mpu9250-spi.rs
@@ -11,7 +11,7 @@
 // for a non_exhaustive struct.
 #![allow(clippy::field_reassign_with_default)]
 
-extern crate teensy4_panic;
+use shared as _;
 
 use cortex_m_rt::entry;
 use motion_sensor::*;

--- a/firmware/demos-teensy4/pwm-control/main.rs
+++ b/firmware/demos-teensy4/pwm-control/main.rs
@@ -95,7 +95,7 @@ mod datapath;
 mod parser;
 mod sensor;
 
-extern crate teensy4_panic;
+use shared as _;
 
 use bsp::hal::i2c::ClockSpeed;
 use core::time::Duration;

--- a/firmware/demos-teensy4/pwm-control/main.rs
+++ b/firmware/demos-teensy4/pwm-control/main.rs
@@ -212,10 +212,7 @@ fn main() -> ! {
     let datapath = match Datapath::new(usb_writer) {
         Ok(datapath) => datapath,
         Err(err) => {
-            log::error!("Unable to establish datapath: {:?}", err);
-            loop {
-                core::hint::spin_loop();
-            }
+            panic!("Unable to establish datapath: {:?}", err);
         }
     };
 
@@ -232,15 +229,10 @@ fn main() -> ! {
     match i2c3.set_clock_speed(I2C_CLOCK_SPEED) {
         Ok(_) => (),
         Err(err) => {
-            log::error!(
+            panic!(
                 "Unable to set I2C clock speed to {:?}: {:?}",
-                I2C_CLOCK_SPEED,
-                err
+                I2C_CLOCK_SPEED, err
             );
-            loop {
-                // Nothing more to do
-                core::hint::spin_loop();
-            }
         }
     }
 

--- a/firmware/demos-teensy4/shared/lib.rs
+++ b/firmware/demos-teensy4/shared/lib.rs
@@ -1,0 +1,11 @@
+//! Shared code for all Teensy 4 demos
+//!
+//! This includes the panic handler.
+
+#![no_std]
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    log::error!("PANIC! {}", info);
+    teensy4_panic::sos()
+}


### PR DESCRIPTION
Turn "log an error, then loop forever" behaviors into actual `panics!`. A [panic](https://doc.rust-lang.org/book/ch09-01-unrecoverable-errors-with-panic.html) indicates an unrecoverable error. Panicking is useful in demos, where we want to catch programming errors. However, we'll need to be careful with panicking in final system.

When a panic happens, we emit an error-level log message, then blink SOS in morse code on the LED. If you ever see that LED pattern, something is wrong. See the [`teensy4-panic` docs](https://crates.io/crates/teensy4-panic) for more information.